### PR TITLE
#27 Add UUIDv7 Strategy for creating new IDs (#45)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "pg-promise": "^11.10.2",
+    "uuid": "^11.0.4",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/backend/src/application/account/usecase/CreateProfile.ts
+++ b/backend/src/application/account/usecase/CreateProfile.ts
@@ -1,5 +1,6 @@
 import { Inject } from "../../../infra/di/DependencyInjection";
 import { ApplicationException } from "../../../infra/exception/ApplicationException";
+import { CreateNewId } from "../../id/usecase/CreateNewId";
 import { Profile } from "../Profile";
 import { Authenticate } from "./Authenticate";
 import { CheckDocumentNumber } from "./CheckDocumentNumber";
@@ -17,6 +18,9 @@ export class CreateProfile {
 
   @Inject("CheckZipCode")
   checkZipCode: CheckZipCode;
+
+  @Inject("CreateNewId")
+  createNewId: CreateNewId;
 
   async execute(
     token: string,
@@ -56,12 +60,12 @@ export class CreateProfile {
         "Invalid zip code"
       );
     }
-    profile.id = crypto.randomUUID();
+    profile.id = await this.createNewId.execute();
     profile.accountId = account.id!;
     profile.createdAt = new Date().toISOString();
     profile.updatedAt = new Date().toISOString();
     profile.address.profileId = profile.id;
-    profile.address.id = crypto.randomUUID();
+    profile.address.id = await this.createNewId.execute();
     profile.address.createdAt = new Date().toISOString();
     profile.address.updatedAt = new Date().toISOString();
     await this.profilesRepository.create(profile);

--- a/backend/src/application/account/usecase/Signup.ts
+++ b/backend/src/application/account/usecase/Signup.ts
@@ -1,5 +1,6 @@
 import { Inject } from "../../../infra/di/DependencyInjection";
 import { ApplicationException } from "../../../infra/exception/ApplicationException";
+import { CreateNewId } from "../../id/usecase/CreateNewId";
 import { Account } from "../Account";
 import { AccountValidator } from "../validator/AccountValidator";
 
@@ -9,6 +10,9 @@ export class Signup {
 
   @Inject("PasswordHasher")
   passwordHasher: SignupPasswordHasher;
+
+  @Inject("CreateNewId")
+  createNewId: CreateNewId;
 
   async execute(account: Account): Promise<{ accountId: string }> {
     AccountValidator.validate(account);
@@ -22,7 +26,7 @@ export class Signup {
         "Account already exists"
       );
     }
-    account.id = crypto.randomUUID();
+    account.id = await this.createNewId.execute();
     account.createdAt = new Date().toISOString();
     account.updatedAt = new Date().toISOString();
     const hashedPassword = await this.passwordHasher.hash(account.password);

--- a/backend/src/application/id/strategy/IdStrategy.ts
+++ b/backend/src/application/id/strategy/IdStrategy.ts
@@ -1,0 +1,7 @@
+export interface IdStrategy {
+  generate(): string;
+}
+
+export enum IdStrategyType {
+  UUIDv7 = "UUIDv7",
+}

--- a/backend/src/application/id/strategy/UUIDv7Strategy.ts
+++ b/backend/src/application/id/strategy/UUIDv7Strategy.ts
@@ -1,0 +1,8 @@
+import { IdStrategy } from "./IdStrategy";
+import { v7 as UUIDv7 } from "uuid";
+
+export class UUIDv7Strategy implements IdStrategy {
+  generate(): string {
+    return UUIDv7();
+  }
+}

--- a/backend/src/application/id/usecase/CreateNewId.ts
+++ b/backend/src/application/id/usecase/CreateNewId.ts
@@ -1,0 +1,13 @@
+import { IdStrategy, IdStrategyType } from "../strategy/IdStrategy";
+
+export class CreateNewId {
+  private readonly strategy: IdStrategy;
+
+  constructor(strategy: IdStrategy) {
+    this.strategy = strategy;
+  }
+
+  async execute(): Promise<string> {
+    return this.strategy.generate();
+  }
+}

--- a/backend/src/application/pet/usecase/CreatePet.ts
+++ b/backend/src/application/pet/usecase/CreatePet.ts
@@ -2,6 +2,7 @@ import { Inject } from "../../../infra/di/DependencyInjection";
 import { ApplicationException } from "../../../infra/exception/ApplicationException";
 import { Profile } from "../../account/Profile";
 import { Authenticate } from "../../account/usecase/Authenticate";
+import { CreateNewId } from "../../id/usecase/CreateNewId";
 import { Pet } from "../Pet";
 import { PetValidator } from "../validator/PetValidator";
 
@@ -14,6 +15,9 @@ export class CreatePet {
 
   @Inject("Authenticate")
   authenticate: Authenticate;
+
+  @Inject("CreateNewId")
+  createNewId: CreateNewId;
 
   async execute(token: string, pet: Pet): Promise<{ petId: string }> {
     const account = await this.authenticate.execute(token);
@@ -29,7 +33,7 @@ export class CreatePet {
     }
 
     PetValidator.validate(pet);
-    pet.id = crypto.randomUUID();
+    pet.id = await this.createNewId.execute();
     pet.createdAt = new Date().toISOString();
     pet.updatedAt = new Date().toISOString();
     pet.birthday = new Date(pet.birthday).toISOString();

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,6 +7,8 @@ import { Login } from "./application/account/usecase/Login";
 import { SetPreferences } from "./application/account/usecase/SetPreferences";
 import { Signup } from "./application/account/usecase/Signup";
 import { HealthCheck } from "./application/health/usecase/HealthCheck";
+import { UUIDv7Strategy } from "./application/id/strategy/UUIDv7Strategy";
+import { CreateNewId } from "./application/id/usecase/CreateNewId";
 import { CreatePet } from "./application/pet/usecase/CreatePet";
 import { ListPets } from "./application/pet/usecase/ListPets";
 import { CreateReport } from "./application/report/usecase/CreateReport";
@@ -53,6 +55,10 @@ Registry.getInstance().provide(
 Registry.getInstance().provide(
   "ReportsRepository",
   new PostgresReportsRepository()
+);
+Registry.getInstance().provide(
+  "CreateNewId",
+  new CreateNewId(new UUIDv7Strategy())
 );
 Registry.getInstance().provide("PasswordHasher", new BCryptAdapter());
 Registry.getInstance().provide("TokenGenerator", new JwtGenerator());

--- a/backend/tests/application/account/CreateProfile.test.ts
+++ b/backend/tests/application/account/CreateProfile.test.ts
@@ -1,5 +1,7 @@
 import { Profile } from "../../../src/application/account/Profile";
 import { CreateProfile } from "../../../src/application/account/usecase/CreateProfile";
+import { UUIDv7Strategy } from "../../../src/application/id/strategy/UUIDv7Strategy";
+import { CreateNewId } from "../../../src/application/id/usecase/CreateNewId";
 import { ApplicationException } from "../../../src/infra/exception/ApplicationException";
 import { mockAuthenticate } from "../../helpers/Mock";
 
@@ -26,6 +28,7 @@ describe("CreateProfile", () => {
       },
       execute: jest.fn().mockResolvedValue({ valid: true }),
     };
+    service.createNewId = new CreateNewId(new UUIDv7Strategy());
     profile = {
       accountId: "12345678",
       fullname: "John Doe",

--- a/backend/tests/application/account/SetPreferences.test.ts
+++ b/backend/tests/application/account/SetPreferences.test.ts
@@ -1,5 +1,6 @@
 import { SetPreferences } from "../../../src/application/account/usecase/SetPreferences";
-import { ApplicationException } from "../../../src/infra/exception/ApplicationException";
+import { UUIDv7Strategy } from "../../../src/application/id/strategy/UUIDv7Strategy";
+import { CreateNewId } from "../../../src/application/id/usecase/CreateNewId";
 
 describe("SetPreferences", () => {
   let service: SetPreferences;
@@ -20,6 +21,7 @@ describe("SetPreferences", () => {
       deleteAll: jest.fn(),
       save: jest.fn(),
     };
+    service.createNewId = new CreateNewId(new UUIDv7Strategy());
   });
 
   it("should set preferences", async () => {

--- a/backend/tests/application/account/Signup.test.ts
+++ b/backend/tests/application/account/Signup.test.ts
@@ -6,6 +6,8 @@ import {
 } from "../../../src/application/account/usecase/Signup";
 import { Account } from "../../../src/application/account/Account";
 import { ApplicationException } from "../../../src/infra/exception/ApplicationException";
+import { UUIDv7Strategy } from "../../../src/application/id/strategy/UUIDv7Strategy";
+import { CreateNewId } from "../../../src/application/id/usecase/CreateNewId";
 
 describe("Signup", () => {
   let service: Signup;
@@ -23,6 +25,7 @@ describe("Signup", () => {
     service = new Signup();
     service.accountsRepository = accountsRepository;
     service.passwordHasher = passwordHasher;
+    service.createNewId = new CreateNewId(new UUIDv7Strategy());
   });
 
   it("should create an account", async () => {

--- a/backend/tests/application/pet/CreatePet.test.ts
+++ b/backend/tests/application/pet/CreatePet.test.ts
@@ -1,3 +1,5 @@
+import { UUIDv7Strategy } from "../../../src/application/id/strategy/UUIDv7Strategy";
+import { CreateNewId } from "../../../src/application/id/usecase/CreateNewId";
 import { Pet } from "../../../src/application/pet/Pet";
 import { CreatePet } from "../../../src/application/pet/usecase/CreatePet";
 import { ApplicationException } from "../../../src/infra/exception/ApplicationException";
@@ -26,6 +28,7 @@ describe("Create Pet", () => {
     service.profilesRepository = {
       getByAccountId: jest.fn(),
     };
+    service.createNewId = new CreateNewId(new UUIDv7Strategy());
   });
 
   afterEach(() => {

--- a/backend/tests/application/report/CreateReport.test.ts
+++ b/backend/tests/application/report/CreateReport.test.ts
@@ -2,6 +2,8 @@ import { faker } from "@faker-js/faker";
 import { Reason, Report } from "../../../src/application/report/Report";
 import { CreateReport } from "../../../src/application/report/usecase/CreateReport";
 import { mockAuthenticate } from "../../helpers/Mock";
+import { UUIDv7Strategy } from "../../../src/application/id/strategy/UUIDv7Strategy";
+import { CreateNewId } from "../../../src/application/id/usecase/CreateNewId";
 
 describe("CreateReport", () => {
   let service: CreateReport;
@@ -24,6 +26,7 @@ describe("CreateReport", () => {
       close: jest.fn(),
       healthCheck: jest.fn(),
     };
+    service.createNewId = new CreateNewId(new UUIDv7Strategy());
   });
 
   it("should create a report", async () => {

--- a/backend/tests/helpers/Mock.ts
+++ b/backend/tests/helpers/Mock.ts
@@ -1,3 +1,5 @@
+import { IdStrategy } from "../../src/application/id/strategy/IdStrategy";
+
 export function mockAuthenticate() {
   return {
     accountsRepository: {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -4550,6 +4550,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.4.tgz#37943977894ef806d2919a7ca3f89d6e23c60bac"
+  integrity sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a centralized ID generation abstraction and migrates all creations to use it.
> 
> - Adds `CreateNewId` use case with `UUIDv7Strategy` (using `uuid`), registered via DI in `main.ts`
> - Replaces `crypto.randomUUID()` with `await createNewId.execute()` in `Signup`, `CreateProfile` (and address), `CreatePet`, and `CreateReport` (including event IDs)
> - Updates `SetPreferences` to asynchronously generate IDs via `Promise.all`
> - Adds `uuid` dependency and updates tests to use `CreateNewId`/`UUIDv7Strategy`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e3c18d4e4833851bc98c629382c8c0028662a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->